### PR TITLE
feat(missions): CRUD missions/roles/assignments, validations dates/overlap, audit log, FE liste+detail (Jalon 4)

### DIFF
--- a/backend/app/api/v1/missions.py
+++ b/backend/app/api/v1/missions.py
@@ -1,0 +1,271 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from sqlalchemy import and_, or_, select
+from sqlalchemy.orm import Session
+
+from ...audit import write_audit
+from ...deps import get_current_user_id, get_db
+from ...models import Assignment, Mission, MissionRole
+from ...schemas import (
+    AssignmentCreate,
+    AssignmentOut,
+    MissionCreate,
+    MissionDetail,
+    MissionOut,
+    MissionRoleCreate,
+    MissionRoleOut,
+    MissionRoleUpdate,
+    MissionUpdate,
+)
+
+router = APIRouter(prefix="/missions", tags=["missions"])
+
+
+def _ensure_bounds(m: Mission) -> None:
+    if m.end_at <= m.start_at:
+        raise HTTPException(status_code=422, detail="end_at doit etre > start_at")
+
+
+def _role_inside_mission(m: Mission, start_at: datetime | None, end_at: datetime | None) -> None:
+    if start_at and start_at < m.start_at:
+        raise HTTPException(status_code=422, detail="role.start_at hors mission")
+    if end_at and end_at > m.end_at:
+        raise HTTPException(status_code=422, detail="role.end_at hors mission")
+    if start_at and end_at and end_at <= start_at:
+        raise HTTPException(status_code=422, detail="role.end_at doit etre > role.start_at")
+
+
+def _assignment_inside_mission(m: Mission, start_at: datetime, end_at: datetime) -> None:
+    if start_at < m.start_at or end_at > m.end_at:
+        raise HTTPException(status_code=422, detail="assignment hors mission")
+    if end_at <= start_at:
+        raise HTTPException(status_code=422, detail="assignment end_at doit etre > start_at")
+
+
+def _overlap_exists(db: Session, user_id: int, start_at: datetime, end_at: datetime, exclude_id: int | None = None) -> bool:
+    q = select(Assignment).where(
+        Assignment.user_id == user_id,
+        Assignment.start_at < end_at,
+        Assignment.end_at > start_at,
+    )
+    if exclude_id:
+        q = q.where(Assignment.id != exclude_id)
+    return db.scalar(q.limit(1)) is not None
+
+
+@router.get("", response_model=list[MissionOut])
+def list_missions(
+    _: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> list[MissionOut]:
+    rows = db.scalars(select(Mission).order_by(Mission.start_at.desc()).limit(limit).offset(offset)).all()
+    return [MissionOut.model_validate(x) for x in rows]
+
+
+@router.post("", response_model=MissionOut, status_code=201)
+def create_mission(
+    body: MissionCreate,
+    user_id: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> MissionOut:
+    m = Mission(
+        title=body.title,
+        location=body.location,
+        start_at=body.start_at,
+        end_at=body.end_at,
+        description=body.description,
+    )
+    _ensure_bounds(m)
+    db.add(m)
+    db.commit()
+    db.refresh(m)
+    write_audit(db, actor_user_id=user_id, action="mission.create", entity="mission", entity_id=m.id, details={"title": m.title})
+    return MissionOut.model_validate(m)
+
+
+@router.get("/{mid}", response_model=MissionDetail)
+def get_mission(
+    mid: int = Path(..., ge=1),
+    _: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> MissionDetail:
+    m = db.get(Mission, mid)
+    if not m:
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    roles = db.scalars(select(MissionRole).where(MissionRole.mission_id == m.id)).all()
+    assigns = db.scalars(select(Assignment).where(Assignment.mission_id == m.id)).all()
+    return MissionDetail.model_validate(
+        {
+            "id": m.id,
+            "title": m.title,
+            "location": m.location,
+            "start_at": m.start_at,
+            "end_at": m.end_at,
+            "description": m.description,
+            "roles": [MissionRoleOut.model_validate(r).model_dump() for r in roles],
+            "assignments": [AssignmentOut.model_validate(a).model_dump() for a in assigns],
+        }
+    )
+
+
+@router.patch("/{mid}", response_model=MissionOut)
+def update_mission(
+    mid: int,
+    body: MissionUpdate,
+    user_id: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> MissionOut:
+    m = db.get(Mission, mid)
+    if not m:
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    if body.title is not None:
+        m.title = body.title
+    if body.location is not None:
+        m.location = body.location
+    if body.start_at is not None:
+        m.start_at = body.start_at
+    if body.end_at is not None:
+        m.end_at = body.end_at
+    if body.description is not None:
+        m.description = body.description
+    _ensure_bounds(m)
+    db.commit()
+    db.refresh(m)
+    write_audit(db, actor_user_id=user_id, action="mission.update", entity="mission", entity_id=m.id, details={"title": m.title})
+    return MissionOut.model_validate(m)
+
+
+@router.delete("/{mid}", status_code=204)
+def delete_mission(
+    mid: int,
+    user_id: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> None:
+    m = db.get(Mission, mid)
+    if not m:
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    db.delete(m)
+    db.commit()
+    write_audit(db, actor_user_id=user_id, action="mission.delete", entity="mission", entity_id=mid, details={})
+    return None
+
+
+# --- Roles ---
+
+@router.get("/{mid}/roles", response_model=list[MissionRoleOut])
+def list_roles(mid: int, _: int = Depends(get_current_user_id), db: Session = Depends(get_db)) -> list[MissionRoleOut]:
+    if not db.get(Mission, mid):
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    rows = db.scalars(select(MissionRole).where(MissionRole.mission_id == mid)).all()
+    return [MissionRoleOut.model_validate(r) for r in rows]
+
+
+@router.post("/{mid}/roles", response_model=MissionRoleOut, status_code=201)
+def create_role(
+    mid: int,
+    body: MissionRoleCreate,
+    user_id: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> MissionRoleOut:
+    m = db.get(Mission, mid)
+    if not m:
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    _role_inside_mission(m, body.start_at, body.end_at)
+    r = MissionRole(mission_id=mid, name=body.name, start_at=body.start_at, end_at=body.end_at, quantity=body.quantity)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    write_audit(db, actor_user_id=user_id, action="role.create", entity="role", entity_id=r.id, details={"mission_id": mid})
+    return MissionRoleOut.model_validate(r)
+
+
+@router.patch("/{mid}/roles/{rid}", response_model=MissionRoleOut)
+def update_role(
+    mid: int,
+    rid: int,
+    body: MissionRoleUpdate,
+    user_id: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> MissionRoleOut:
+    m = db.get(Mission, mid)
+    if not m:
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    r = db.get(MissionRole, rid)
+    if not r or r.mission_id != mid:
+        raise HTTPException(status_code=404, detail="Role introuvable")
+    start = body.start_at if body.start_at is not None else r.start_at
+    end = body.end_at if body.end_at is not None else r.end_at
+    _role_inside_mission(m, start, end)
+
+    if body.name is not None:
+        r.name = body.name
+    if body.start_at is not None:
+        r.start_at = body.start_at
+    if body.end_at is not None:
+        r.end_at = body.end_at
+    if body.quantity is not None:
+        r.quantity = body.quantity
+    db.commit()
+    db.refresh(r)
+    write_audit(db, actor_user_id=user_id, action="role.update", entity="role", entity_id=r.id, details={"mission_id": mid})
+    return MissionRoleOut.model_validate(r)
+
+
+@router.delete("/{mid}/roles/{rid}", status_code=204)
+def delete_role(mid: int, rid: int, user_id: int = Depends(get_current_user_id), db: Session = Depends(get_db)) -> None:
+    r = db.get(MissionRole, rid)
+    if not r or r.mission_id != mid:
+        raise HTTPException(status_code=404, detail="Role introuvable")
+    db.delete(r)
+    db.commit()
+    write_audit(db, actor_user_id=user_id, action="role.delete", entity="role", entity_id=rid, details={"mission_id": mid})
+    return None
+
+
+# --- Assignments ---
+
+@router.get("/{mid}/assignments", response_model=list[AssignmentOut])
+def list_assignments(mid: int, _: int = Depends(get_current_user_id), db: Session = Depends(get_db)) -> list[AssignmentOut]:
+    if not db.get(Mission, mid):
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    rows = db.scalars(select(Assignment).where(Assignment.mission_id == mid)).all()
+    return [AssignmentOut.model_validate(a) for a in rows]
+
+
+@router.post("/{mid}/assignments", response_model=AssignmentOut, status_code=201)
+def create_assignment(
+    mid: int,
+    body: AssignmentCreate,
+    user_id: int = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> AssignmentOut:
+    m = db.get(Mission, mid)
+    if not m:
+        raise HTTPException(status_code=404, detail="Mission introuvable")
+    if body.role_id is not None:
+        r = db.get(MissionRole, body.role_id)
+        if not r or r.mission_id != mid:
+            raise HTTPException(status_code=404, detail="Role introuvable")
+    _assignment_inside_mission(m, body.start_at, body.end_at)
+    if _overlap_exists(db, user_id=body.user_id, start_at=body.start_at, end_at=body.end_at):
+        raise HTTPException(status_code=409, detail="Assignment overlap pour cet utilisateur")
+    a = Assignment(mission_id=mid, role_id=body.role_id, user_id=body.user_id, start_at=body.start_at, end_at=body.end_at)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    write_audit(db, actor_user_id=user_id, action="assignment.create", entity="assignment", entity_id=a.id, details={"mission_id": mid})
+    return AssignmentOut.model_validate(a)
+
+
+@router.delete("/{mid}/assignments/{aid}", status_code=204)
+def delete_assignment(mid: int, aid: int, user_id: int = Depends(get_current_user_id), db: Session = Depends(get_db)) -> None:
+    a = db.get(Assignment, aid)
+    if not a or a.mission_id != mid:
+        raise HTTPException(status_code=404, detail="Assignment introuvable")
+    db.delete(a)
+    db.commit()
+    write_audit(db, actor_user_id=user_id, action="assignment.delete", entity="assignment", entity_id=aid, details={"mission_id": mid})
+    return None

--- a/backend/app/audit.py
+++ b/backend/app/audit.py
@@ -1,0 +1,15 @@
+import logging
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from .models import AuditLog
+
+log = logging.getLogger("audit")
+
+
+def write_audit(db: Session, *, actor_user_id: Optional[int], action: str, entity: str, entity_id: str, details: Dict[str, Any] | None = None) -> None:
+    rec = AuditLog(actor_user_id=actor_user_id, action=action, entity=entity, entity_id=str(entity_id), details=details or {})
+    db.add(rec)
+    db.commit()
+    log.info("audit", extra={"action": action, "entity": entity, "entity_id": entity_id})

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,8 @@
-
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api.v1.auth import router as auth_router
+from .api.v1.missions import router as missions_router
 from .api.v1.router import router as v1_meta_router
 from .api.v1.users import router as users_router
 from .config import get_settings
@@ -30,8 +30,9 @@ def create_app() -> FastAPI:
     app.include_router(v1_meta_router, prefix="/api/v1")
     app.include_router(auth_router, prefix="/api/v1")
     app.include_router(users_router, prefix="/api/v1")
+    app.include_router(missions_router, prefix="/api/v1")
+
     return app
 
 
 app = create_app()
-

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,12 +1,22 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .db import Base
 
+# --- Auth models (J3) ---
 
 class User(Base):
     __tablename__ = "users"
@@ -37,6 +47,61 @@ class RefreshToken(Base):
     revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
     user: Mapped["User"] = relationship(back_populates="refresh_tokens")
-
     __table_args__ = (UniqueConstraint("token_hash", name="uq_refresh_token_hash"),)
 
+# --- Missions models (J4) ---
+
+class Mission(Base):
+    __tablename__ = "missions"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    location: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    start_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    end_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    description: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    roles: Mapped[list["MissionRole"]] = relationship(back_populates="mission", cascade="all, delete-orphan")
+    assignments: Mapped[list["Assignment"]] = relationship(back_populates="mission", cascade="all, delete-orphan")
+
+
+class MissionRole(Base):
+    __tablename__ = "mission_roles"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    mission_id: Mapped[int] = mapped_column(ForeignKey("missions.id", ondelete="CASCADE"), index=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    start_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    end_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    quantity: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+
+    mission: Mapped["Mission"] = relationship(back_populates="roles")
+
+
+class Assignment(Base):
+    __tablename__ = "assignments"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    mission_id: Mapped[int] = mapped_column(ForeignKey("missions.id", ondelete="CASCADE"), index=True, nullable=False)
+    role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("mission_roles.id", ondelete="SET NULL"), nullable=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="RESTRICT"), index=True, nullable=False)
+    start_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    end_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+
+    mission: Mapped["Mission"] = relationship(back_populates="assignments")
+    role: Mapped[Optional["MissionRole"]] = relationship()
+    user: Mapped["User"] = relationship()
+
+# --- Audit log (J4) ---
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    actor_user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    action: Mapped[str] = mapped_column(String(64), nullable=False)  # e.g., mission.create
+    entity: Mapped[str] = mapped_column(String(64), nullable=False)  # e.g., mission, role, assignment
+    entity_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    details: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+
+    actor: Mapped[Optional["User"]] = relationship()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,12 +2,15 @@ import re
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
+# --- Users (J3) ---
+
 class UserCreate(BaseModel):
+    model_config = ConfigDict(strict=True)
     email: str = Field(...)
     password: str = Field(min_length=8)
 
@@ -20,6 +23,7 @@ class UserCreate(BaseModel):
 
 
 class UserOut(BaseModel):
+    model_config = ConfigDict(strict=True, from_attributes=True)
     id: int
     email: str
     is_active: bool
@@ -27,16 +31,15 @@ class UserOut(BaseModel):
     totp_enabled: bool
     created_at: datetime
 
-    class Config:
-        from_attributes = True
-
 
 class UserUpdate(BaseModel):
+    model_config = ConfigDict(strict=True)
     is_active: Optional[bool] = None
     is_admin: Optional[bool] = None
 
 
 class TokenPair(BaseModel):
+    model_config = ConfigDict(strict=True)
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
@@ -44,7 +47,110 @@ class TokenPair(BaseModel):
 
 
 class LoginIn(BaseModel):
+    model_config = ConfigDict(strict=True)
     email: str
     password: str
     totp_code: Optional[str] = None
+
+
+# --- Missions (J4) ---
+
+class MissionBase(BaseModel):
+    model_config = ConfigDict(strict=True)
+    title: str = Field(min_length=2)
+    location: Optional[str] = None
+    start_at: datetime
+    end_at: datetime
+    description: Optional[str] = None
+
+    @field_validator("end_at")
+    @classmethod
+    def _end_after_start(cls, v: datetime, info):
+        start = info.data.get("start_at")
+        if isinstance(start, datetime) and v <= start:
+            raise ValueError("end_at doit etre > start_at")
+        return v
+
+
+class MissionCreate(MissionBase):
+    pass
+
+
+class MissionUpdate(BaseModel):
+    model_config = ConfigDict(strict=True)
+    title: Optional[str] = None
+    location: Optional[str] = None
+    start_at: Optional[datetime] = None
+    end_at: Optional[datetime] = None
+    description: Optional[str] = None
+
+    @field_validator("end_at")
+    @classmethod
+    def _end_after_start(cls, v: Optional[datetime], info):
+        start = info.data.get("start_at")
+        if v is not None and start is not None and v <= start:
+            raise ValueError("end_at doit etre > start_at")
+        return v
+
+
+class MissionOut(MissionBase):
+    model_config = ConfigDict(strict=True, from_attributes=True)
+    id: int
+
+
+class MissionDetail(MissionOut):
+    roles: list["MissionRoleOut"] = []
+    assignments: list["AssignmentOut"] = []
+
+
+class MissionRoleCreate(BaseModel):
+    model_config = ConfigDict(strict=True)
+    name: str = Field(min_length=2)
+    start_at: Optional[datetime] = None
+    end_at: Optional[datetime] = None
+    quantity: int = Field(default=1, ge=1)
+
+
+class MissionRoleUpdate(BaseModel):
+    model_config = ConfigDict(strict=True)
+    name: Optional[str] = None
+    start_at: Optional[datetime] = None
+    end_at: Optional[datetime] = None
+    quantity: Optional[int] = Field(default=None, ge=1)
+
+
+class MissionRoleOut(BaseModel):
+    model_config = ConfigDict(strict=True, from_attributes=True)
+    id: int
+    mission_id: int
+    name: str
+    start_at: Optional[datetime] = None
+    end_at: Optional[datetime] = None
+    quantity: int
+
+
+class AssignmentCreate(BaseModel):
+    model_config = ConfigDict(strict=True)
+    user_id: int
+    start_at: datetime
+    end_at: datetime
+    role_id: Optional[int] = None
+
+    @field_validator("end_at")
+    @classmethod
+    def _end_after_start(cls, v: datetime, info):
+        start = info.data.get("start_at")
+        if isinstance(start, datetime) and v <= start:
+            raise ValueError("end_at doit etre > start_at")
+        return v
+
+
+class AssignmentOut(BaseModel):
+    model_config = ConfigDict(strict=True, from_attributes=True)
+    id: int
+    mission_id: int
+    user_id: int
+    role_id: Optional[int] = None
+    start_at: datetime
+    end_at: datetime
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -5,4 +5,4 @@ pytest-cov==5.0.0
 pip-audit==2.7.3
 bandit==1.7.9
 httpx==0.27.2
-
+hypothesis==6.112.1

--- a/backend/tests/test_mission_validations.py
+++ b/backend/tests/test_mission_validations.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+from hypothesis import given, strategies as st
+
+from app.main import app
+
+
+def auth(client: TestClient):
+    client.post("/api/v1/auth/register", json={"email": "vv@example.com", "password": "Passw0rd!"})
+    r = client.post("/api/v1/auth/login", json={"email": "vv@example.com", "password": "Passw0rd!"})
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+def test_mission_invalid_dates_422():
+    c = TestClient(app)
+    h = auth(c)
+    now = datetime.now(timezone.utc)
+    r = c.post("/api/v1/missions", headers=h, json={"title": "X", "start_at": now.isoformat(), "end_at": now.isoformat()})
+    assert r.status_code == 422
+
+
+@given(
+    start_ts=st.integers(min_value=1_700_000_000, max_value=2_000_000_000),
+    dur=st.integers(min_value=1, max_value=24 * 3600),
+)
+def test_property_mission_dates_ok(start_ts, dur):
+    c = TestClient(app)
+    h = auth(c)
+    start = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+    end = start + timedelta(seconds=dur)
+    r = c.post("/api/v1/missions", headers=h, json={"title": "P", "start_at": start.isoformat(), "end_at": end.isoformat()})
+    assert r.status_code == 201
+
+
+def test_assignment_overlap_409():
+    c = TestClient(app)
+    h = auth(c)
+    now = datetime.now(timezone.utc)
+    start = now + timedelta(days=1)
+    end = start + timedelta(hours=8)
+    # mission A
+    ma = c.post("/api/v1/missions", headers=h, json={"title": "A", "start_at": start.isoformat(), "end_at": end.isoformat()}).json()
+    me = c.get("/api/v1/users/me", headers=h).json()
+    a1start = start + timedelta(hours=1)
+    a1end = a1start + timedelta(hours=4)
+    a2start = a1start + timedelta(hours=2)  # overlap
+    a2end = a2start + timedelta(hours=3)
+    r1 = c.post(f"/api/v1/missions/{ma['id']}/assignments", headers=h, json={"user_id": me["id"], "start_at": a1start.isoformat(), "end_at": a1end.isoformat()})
+    assert r1.status_code == 201
+    r2 = c.post(f"/api/v1/missions/{ma['id']}/assignments", headers=h, json={"user_id": me["id"], "start_at": a2start.isoformat(), "end_at": a2end.isoformat()})
+    assert r2.status_code == 409

--- a/backend/tests/test_missions_crud.py
+++ b/backend/tests/test_missions_crud.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def auth(client: TestClient, email="u@example.com", pwd="Passw0rd!"):
+    client.post("/api/v1/auth/register", json={"email": email, "password": pwd})
+    r = client.post("/api/v1/auth/login", json={"email": email, "password": pwd})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+def test_mission_crud_ok():
+    c = TestClient(app)
+    h = auth(c)
+
+    start = datetime.now(timezone.utc) + timedelta(days=1)
+    end = start + timedelta(hours=8)
+
+    r = c.post("/api/v1/missions", headers=h, json={"title": "Montage", "location": "Bobino", "start_at": start.isoformat(), "end_at": end.isoformat()})
+    assert r.status_code == 201, r.text
+    mid = r.json()["id"]
+
+    # read
+    r = c.get(f"/api/v1/missions/{mid}", headers=h)
+    assert r.status_code == 200
+    assert r.json()["title"] == "Montage"
+
+    # update
+    r = c.patch(f"/api/v1/missions/{mid}", headers=h, json={"location": "Bobino - Cour"})
+    assert r.status_code == 200
+    assert r.json()["location"] == "Bobino - Cour"
+
+    # roles
+    r = c.post(f"/api/v1/missions/{mid}/roles", headers=h, json={"name": "Son", "quantity": 2})
+    assert r.status_code == 201
+    rid = r.json()["id"]
+
+    # assignments
+    a_start = start + timedelta(hours=1)
+    a_end = a_start + timedelta(hours=4)
+    # Need a user to assign: reuse same user id by calling /users/me
+    me = c.get("/api/v1/users/me", headers=h).json()
+    r = c.post(f"/api/v1/missions/{mid}/assignments", headers=h, json={"user_id": me["id"], "role_id": rid, "start_at": a_start.isoformat(), "end_at": a_end.isoformat()})
+    assert r.status_code == 201
+
+    # delete assignment
+    aid = r.json()["id"]
+    r = c.delete(f"/api/v1/missions/{mid}/assignments/{aid}", headers=h)
+    assert r.status_code == 204
+
+    # delete role
+    r = c.delete(f"/api/v1/missions/{mid}/roles/{rid}", headers=h)
+    assert r.status_code == 204
+
+    # delete mission
+    r = c.delete(f"/api/v1/missions/{mid}", headers=h)
+    assert r.status_code == 204

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,33 +15,21 @@ Conventions:
 - RGPD: export, droit a l oubli, retention 30j dev/stage, 90j prod
 
 Jalon 0 - Bootstrap: OK
-- [x] Arborescence creee
-- [x] Fichiers racine complets
-- [x] Workflows CI operatifs
-- [x] pre-commit actif
-- [x] Dependabot actif
-
-Jalon 1 - Backend minimal + Observabilite de base: EN COURS
-- [x] FastAPI demarre (/api/v1)
-- [x] Endpoints GET /health, GET /version
-- [x] Middleware request_id + logs JSON
-- [x] CLI Typer "cc"
-- [x] Tests + scripts PS
-
-Jalon 2 - Frontend base: EN COURS
-- [x] Page /health OK (Loading/OK/KO)
-- [x] Tailwind + UI compatibles shadcn operatifs
-- [x] Lint + build OK
-- [x] Tests vitest OK (+ a11y axe)
-- [x] Storybook OK
-
+Jalon 1 - Backend minimal + Observabilite: OK
+Jalon 2 - Frontend base: OK
 Jalon 3 - Auth v1: EN COURS
-- [ ] CRUD users + login/refresh/logout OK
-- [ ] Hash bcrypt + JWT OK
-- [ ] Rate limit actif (Redis ou memoire)
-- [ ] 2FA TOTP stub
-- [ ] Logs securite + lock progressif
-- [ ] Pages FE Login/Register/Profil + guards
+- [x] CRUD users + login/refresh/logout
+- [x] Hash bcrypt + JWT
+- [x] Rate limit actif (fallback memoire)
+- [x] 2FA TOTP stub
+- [x] Logs securite
+- [ ] RBAC fin (plus tard)
+
+Jalon 4 - Missions v1: EN COURS
+- [ ] CRUD missions/roles/assignments OK
+- [ ] Validations dates OK (coherence + overlap)
+- [ ] Audit log ecrit
+- [ ] Tests property dates
 
 Notes:
 Ce document prime sur les autres. Proposer patch si divergence.

--- a/frontend/src/lib/api_missions.ts
+++ b/frontend/src/lib/api_missions.ts
@@ -1,0 +1,16 @@
+export type Mission = { id: number; title: string; location?: string | null; start_at: string; end_at: string };
+export type MissionDetail = Mission & { roles: Array<{ id: number; name: string; quantity: number }>; assignments: Array<{ id: number; user_id: number }> };
+
+const BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8000/api/v1";
+
+export async function listMissions(token?: string): Promise<Mission[]> {
+  const r = await fetch(`${BASE}/missions`, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
+  if (!r.ok) throw new Error(String(r.status));
+  return (await r.json()) as Mission[];
+}
+
+export async function getMission(id: number, token?: string): Promise<MissionDetail> {
+  const r = await fetch(`${BASE}/missions/${id}`, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
+  if (!r.ok) throw new Error(String(r.status));
+  return (await r.json()) as MissionDetail;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,8 @@ import Health from "./pages/Health";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Profile from "./pages/Profile";
+import Missions from "./pages/Missions";
+import MissionDetails from "./pages/MissionDetails";
 import { getTokens } from "./lib/auth";
 import "./index.css";
 
@@ -16,6 +18,7 @@ function Nav() {
       <div className="max-w-5xl mx-auto p-4 flex gap-4">
         <Link to="/">Accueil</Link>
         <Link to="/health">Health</Link>
+        <Link to="/missions">Missions</Link>
         {!authed && <Link to="/login">Login</Link>}
         {!authed && <Link to="/register">Register</Link>}
         {authed && <Link to="/profile">Profil</Link>}
@@ -36,6 +39,8 @@ function Shell() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/health" element={<Health />} />
+          <Route path="/missions" element={<RequireAuth><Missions /></RequireAuth>} />
+          <Route path="/missions/:id" element={<RequireAuth><MissionDetails /></RequireAuth>} />
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
           <Route path="/profile" element={<RequireAuth><Profile /></RequireAuth>} />
@@ -50,4 +55,3 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <Shell />
   </React.StrictMode>
 );
-

--- a/frontend/src/pages/MissionDetails.tsx
+++ b/frontend/src/pages/MissionDetails.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { getMission } from "../lib/api_missions";
+import { getTokens } from "../lib/auth";
+
+export default function MissionDetails() {
+  const { id } = useParams();
+  const [m, setM] = React.useState<any | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    if (!id) return;
+    const run = async () => {
+      try {
+        const t = getTokens();
+        setM(await getMission(Number(id), t?.access));
+      } catch (e: any) {
+        setErr(`Erreur ${e.message}`);
+      }
+    };
+    void run();
+  }, [id]);
+  if (err) return <div className="text-red-600">{err}</div>;
+  if (!m) return <div>Chargement...</div>;
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{m.title}</h1>
+      <div className="text-sm">{new Date(m.start_at).toLocaleString()} - {new Date(m.end_at).toLocaleString()}</div>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Roles</h2>
+        <ul className="list-disc pl-6">
+          {m.roles.map((r: any) => <li key={r.id}>{r.name} x{r.quantity}</li>)}
+        </ul>
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Assignations</h2>
+        <ul className="list-disc pl-6">
+          {m.assignments.map((a: any) => <li key={a.id}>user #{a.user_id} ({new Date(a.start_at).toLocaleTimeString()} - {new Date(a.end_at).toLocaleTimeString()})</li>)}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Missions.tsx
+++ b/frontend/src/pages/Missions.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { listMissions } from "../lib/api_missions";
+import { getTokens } from "../lib/auth";
+import { Link } from "react-router-dom";
+
+export default function Missions() {
+  const [arr, setArr] = React.useState<any[] | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    const run = async () => {
+      try {
+        const t = getTokens();
+        const data = await listMissions(t?.access);
+        setArr(data);
+      } catch (e: any) {
+        setErr(`Erreur ${e.message}`);
+      }
+    };
+    void run();
+  }, []);
+  if (err) return <div className="text-red-600">{err}</div>;
+  if (!arr) return <div>Chargement...</div>;
+  return (
+    <div className="space-y-3">
+      <h1 className="text-2xl font-bold">Missions</h1>
+      <ul className="space-y-2">
+        {arr.map(m => (
+          <li key={m.id} className="border rounded-xl p-3">
+            <div className="font-semibold">{m.title}</div>
+            <div className="text-sm text-gray-600">{new Date(m.start_at).toLocaleString()} - {new Date(m.end_at).toLocaleString()}</div>
+            <Link to={`/missions/${m.id}`} className="text-blue-600 underline">Details</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add missions, mission roles and assignment models + audit log
- implement missions API with validation and audit writes
- introduce missions list/detail pages and API client

## Testing
- `pwsh -File PS1/init_repo.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `ruff check .` *(fails: 105 errors)*
- `mypy backend/app` *(fails: cannot find stubs for many modules)
- `pytest backend/tests/test_missions_crud.py backend/tests/test_mission_validations.py` *(fails: validation and auth rate limit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acde2fe4188330bc37a616b4ec6a7e